### PR TITLE
06.12.2019 Version 1.0.9

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+06.12.2019 Version 1.0.9
+GEO download queueSize set to 2 by default.
+Initial run max retry amount increase to 4.
+
 04.12.2019 Version 1.0.8
 GEO download cache clean command added.
 

--- a/nf/initialrun.nf
+++ b/nf/initialrun.nf
@@ -506,7 +506,7 @@ process downloadUrl {
 
 process createCollection {
     errorStrategy 'retry'
-    maxRetries 2
+    maxRetries 4
 
     input:
         each failedFile from failedFile.flatten()

--- a/public/ajax/dbfuncs.php
+++ b/public/ajax/dbfuncs.php
@@ -767,7 +767,7 @@ class dbfuncs {
                 $configText .= "executor.queueSize = 4 \n";
             } else if ($checkGeoFiles == "true"){
                 $configText .= "\n//parallel download limit for GEO files:\n";
-                $configText .= "executor.queueSize = 4 \n";
+                $configText .= "executor.queueSize = 2 \n";
             }
         }
         $configText .= "\n//Initial Run Parameters\n".$initialRunParams;


### PR DESCRIPTION
GEO download queueSize set to 2 by default.
Initial run max retry amount increase to 4.