### PR TITLE
04.11.2021 Version 1.2.62

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+04.11.2021 Version 1.2.62
+DolphinNext Debrowser_URL parameter updated. Full link needs to be provided in .sec file.
+
 04.11.2021 Version 1.2.61
 Initial run config updated to support high number of inputs.
 Please select Amazon Keys warning removed from run page.

--- a/public/js/runpipeline.js
+++ b/public/js/runpipeline.js
@@ -14418,7 +14418,8 @@ $(document).ready(function () {
                                 pubWebPath + "/" + uuid + "/" + "pubweb" + "/" + filePathJson
                             );
                             var debrowserlink =
-                                debrowserUrl + "/debrowser/R/?jsonobject=" + link;
+                                debrowserUrl + link;
+                                console.log(debrowserlink)
                             var iframe =
                                 '<iframe id="deb-' +
                                 fileid +


### PR DESCRIPTION
DolphinNext Debrowser_URL parameter updated. Full link needs to be provided in .sec file.